### PR TITLE
Dev

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -1477,6 +1477,8 @@ char *generateAircraftJson(const char *url_path, int *len) {
         if (a->messages < 2) { // basic filter for bad decodes
             continue;
         }
+        if ((now - a->seen) > 70E3) // don't include stale aircraft in the JSON
+            continue;
 
         if (first)
             first = 0;

--- a/track.c
+++ b/track.c
@@ -128,7 +128,7 @@ static struct aircraft *trackCreateAircraft(struct modesMessage *mm) {
     F(nav_modes, 60, 70); // ADS-B or Comm-B
     F(cpr_odd, 60, 70); // ADS-B only
     F(cpr_even, 60, 70); // ADS-B only
-    F(position, 60, 70); // ADS-B only
+    F(position, 60, 12*60); // ADS-B only
     F(nic_a, 60, 70); // ADS-B only
     F(nic_c, 60, 70); // ADS-B only
     F(nic_baro, 60, 70); // ADS-B only
@@ -423,7 +423,15 @@ static int doLocalCPR(struct aircraft *a, struct modesMessage *mm, double *lat, 
         if (a->pos_rc < *rc)
             *rc = a->pos_rc;
 
-        range_limit = 50e3;
+        range_limit = 1852*120; // 120NM
+        // 120 NM in the 12 minutes of position validity means 600 knots which
+        // is fast but happens even for commercial airliners.
+        // A wrong relative position decode would require the aircraft to
+        // travel 360-120=240 NM in the 12 minutes of position validity.
+        // This is impossible for planes slower than 1200 knots/Mach 1.8 over the ground.
+        // Thus this range limit combined with the 12 minutes of position
+        // validity should not provide bad positions (1 cell away).
+
         relative_to = 1;
     } else if (!surface && (Modes.bUserFlags & MODES_USER_LATLON_VALID)) {
         reflat = Modes.fUserLat;

--- a/track.c
+++ b/track.c
@@ -553,9 +553,9 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm) {
                 a->pos_reliable_even = 0;
             }
             // Don't be too reliant on the established position.
-            if (a->pos_reliable_odd > 4 || a->pos_reliable_even > 4) {
-                a->pos_reliable_odd = 4;
-                a->pos_reliable_even = 4;
+            if (a->pos_reliable_odd > 1 || a->pos_reliable_even > 1) {
+                a->pos_reliable_odd = 1;
+                a->pos_reliable_even = 1;
             }
 
             return;

--- a/track.c
+++ b/track.c
@@ -553,9 +553,9 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm) {
                 a->pos_reliable_even = 0;
             }
             // Don't be too reliant on the established position.
-            if (a->pos_reliable_odd > 20 || a->pos_reliable_even > 20) {
-                a->pos_reliable_odd = 20;
-                a->pos_reliable_even = 20;
+            if (a->pos_reliable_odd > 4 || a->pos_reliable_even > 4) {
+                a->pos_reliable_odd = 4;
+                a->pos_reliable_even = 4;
             }
 
             return;

--- a/track.c
+++ b/track.c
@@ -806,6 +806,7 @@ static int altitude_to_feet(int raw, altitude_unit_t unit) {
 
 struct aircraft *trackUpdateFromMessage(struct modesMessage *mm) {
     struct aircraft *a;
+    unsigned int cpr_new = 0;
 
     if (mm->msgtype == 32) {
         // Mode A/C, just count it (we ignore SPI)
@@ -1022,6 +1023,7 @@ struct aircraft *trackUpdateFromMessage(struct modesMessage *mm) {
         a->cpr_even_lat = mm->cpr_lat;
         a->cpr_even_lon = mm->cpr_lon;
         compute_nic_rc_from_message(mm, a, &a->cpr_even_nic, &a->cpr_even_rc);
+        cpr_new = 1;
     }
 
     // CPR, odd
@@ -1030,6 +1032,7 @@ struct aircraft *trackUpdateFromMessage(struct modesMessage *mm) {
         a->cpr_odd_lat = mm->cpr_lat;
         a->cpr_odd_lon = mm->cpr_lon;
         compute_nic_rc_from_message(mm, a, &a->cpr_odd_nic, &a->cpr_odd_rc);
+        cpr_new = 1;
     }
 
     if (mm->accuracy.sda_valid && accept_data(&a->sda_valid, mm->source)) {
@@ -1081,8 +1084,8 @@ struct aircraft *trackUpdateFromMessage(struct modesMessage *mm) {
         combine_validity(&a->altitude_geom_valid, &a->altitude_baro_valid, &a->geom_delta_valid);
     }
 
-    // If we've got a new cprlat or cprlon
-    if (mm->cpr_valid) {
+    // If we've got a new cpr_odd or cpr_even
+    if (cpr_new) {
         updatePosition(a, mm);
     }
 

--- a/track.c
+++ b/track.c
@@ -534,7 +534,7 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm) {
             Modes.stats_current.cpr_global_skipped++;
         } else {
             Modes.stats_current.cpr_global_ok++;
-            combine_validity(&a->position_valid, &a->cpr_even_valid, &a->cpr_odd_valid);
+            accept_data(&a->position_valid, mm->source);
         }
     }
 
@@ -547,12 +547,7 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm) {
         } else {
             Modes.stats_current.cpr_local_ok++;
             mm->cpr_relative = 1;
-
-            if (mm->cpr_odd) {
-                a->position_valid = a->cpr_odd_valid;
-            } else {
-                a->position_valid = a->cpr_even_valid;
-            }
+            accept_data(&a->position_valid, mm->source);
         }
     }
 

--- a/track.c
+++ b/track.c
@@ -395,6 +395,7 @@ static int doLocalCPR(struct aircraft *a, struct modesMessage *mm, double *lat, 
     int result;
     int fflag = mm->cpr_odd;
     int surface = (mm->cpr_type == CPR_SURFACE);
+    int relative_to = 0; // aircraft(1) or receiver(2) relative
 
     if (fflag) {
         *nic = a->cpr_odd_nic;
@@ -414,6 +415,7 @@ static int doLocalCPR(struct aircraft *a, struct modesMessage *mm, double *lat, 
             *rc = a->pos_rc;
 
         range_limit = 50e3;
+        relative_to = 1;
     } else if (!surface && (Modes.bUserFlags & MODES_USER_LATLON_VALID)) {
         reflat = Modes.fUserLat;
         reflon = Modes.fUserLon;
@@ -436,6 +438,7 @@ static int doLocalCPR(struct aircraft *a, struct modesMessage *mm, double *lat, 
         } else {
             return (-1); // Can't do receiver-centered checks at all
         }
+        relative_to = 2;
     } else {
         // No local reference, give up
         return (-1);
@@ -468,7 +471,7 @@ static int doLocalCPR(struct aircraft *a, struct modesMessage *mm, double *lat, 
         return -1;
     }
 
-    return 0;
+    return relative_to;
 }
 
 static uint64_t time_between(uint64_t t1, uint64_t t2) {
@@ -548,10 +551,17 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm) {
             Modes.stats_current.cpr_local_ok++;
             mm->cpr_relative = 1;
             accept_data(&a->position_valid, mm->source);
+
+            if (location_result == 1) {
+                Modes.stats_current.cpr_local_aircraft_relative++;
+            }
+            if (location_result == 2) {
+                Modes.stats_current.cpr_local_receiver_relative++;
+            }
         }
     }
 
-    if (location_result == 0) {
+    if (location_result >= 0) {
         // If we sucessfully decoded, back copy the results to mm so that we can print them in list output
         mm->cpr_decoded = 1;
         mm->decoded_lat = new_lat;

--- a/track.h
+++ b/track.h
@@ -178,6 +178,8 @@ struct aircraft
   double lat, lon; // Coordinated obtained from CPR encoded data
   unsigned pos_nic; // NIC of last computed position
   unsigned pos_rc; // Rc of last computed position
+  int pos_reliable_odd; // Number of good global CPRs, indicates position reliability
+  int pos_reliable_even;
 
   // data extracted from opstatus etc
   int adsb_version; // ADS-B version (from ADS-B operational status); -1 means no ADS-B messages seen

--- a/track.h
+++ b/track.h
@@ -55,13 +55,10 @@
 #define DUMP1090_TRACK_H
 
 /* Maximum age of tracked aircraft in milliseconds */
-#define TRACK_AIRCRAFT_TTL 300000
+#define TRACK_AIRCRAFT_TTL 12*60E3
 
 /* Maximum age of a tracked aircraft with only 1 message received, in milliseconds */
 #define TRACK_AIRCRAFT_ONEHIT_TTL 60000
-
-/* Maximum validity of an aircraft position */
-#define TRACK_AIRCRAFT_POSITION_TTL 60000
 
 /* Minimum number of repeated Mode A/C replies with a particular Mode A code needed in a
  * 1 second period before accepting that code.

--- a/track.h
+++ b/track.h
@@ -180,6 +180,7 @@ struct aircraft
   unsigned pos_rc; // Rc of last computed position
   int pos_reliable_odd; // Number of good global CPRs, indicates position reliability
   int pos_reliable_even;
+  float gs_last_pos; // Save a groundspeed associated with the last position
 
   // data extracted from opstatus etc
   int adsb_version; // ADS-B version (from ADS-B operational status); -1 means no ADS-B messages seen


### PR DESCRIPTION
So this is now much better tested than before.
And i've identified some pitfalls i didn't sufficiently consider before.

I'd probably recommend just reverting the patches i submitted for the master branch.
While they are not totally broken, it'll make it easier to merge the dev branch :)

Testing especially range set to 0 (infinite) provided some nice corner cases.
Due to the global_cpr_bad handling, the filtering needs to me more conservative.
But in my testing i didn't notice the changes making the filter less effective.
What the changes did do though is reduce the false positive filter hits for landing/departing aircraft and in some other situations.

Note that the first patch will reduce the number of global CPRs if you have MLAT enabled as the MLAT CPRs are correctly discarded as long as the ADS-B CPRs are not stale.

An example of the improvements using ADS-B only data from a receiver with view on SFO:
Left side is after the patches, right side is before, you can clearly see after dropping out of view of the receiver the new position is more quickly acquired when the aircraft start their takeoff run.
Thin lines are the intermittent track normally depicted with dotted lines.

https://imgur.com/a/UAL9TYE

These are the CPR stats compared between the commit making the aircraft_relative CPR stat functional and the final commit.
As you can see the number of aircraft_relative CPR has increased because it is used for aircraft that were out of view longer.
```
"cpr":                      {              {
"surface":                  13793,         13793,
"airborne":                 341607,        341607,
"global_ok":                349014,        349022,
"global_bad":               12,            11,
"global_range":             0,             0,
"global_speed":             8,             7,
"global_skipped":           278,           278,
"local_ok":                 4507,          4990,
"local_aircraft_relative":  4507,          4990,
"local_receiver_relative":  0,             0,
"local_skipped":            1867,          1377,
"local_range":              0,             0,
"local_speed":              3,             0,
"filtered":                 0              0
```