### PR TITLE
Position decoding bugfixes + improvements to position filtering and relative decoding

### DIFF
--- a/help.h
+++ b/help.h
@@ -39,6 +39,7 @@ static struct argp_option options[] =
     {"no-crc-check", OptNoCrcCheck, 0, 0, "Disable messages with invalid CRC (discouraged)", 1},
     {"metric", OptMetric, 0, 0, "Use metric units", 1},
     {"show-only", OptShowOnly, "<addr>", 0, "Show only messages by given ICAO on stdout", 1},
+    {"filter-persistence", OptFilterPersistence, "<positions>", 0, "Maximum number of consecutive implausible positions from global CPR to invalidate a known position. (default: 2) ", 1},
     #ifdef ALLOW_AGGRESSIVE
         {"aggressive", OptAggressive, 0, 0, "Enable two-bit CRC error correction", 1},
     #else

--- a/net_io.c
+++ b/net_io.c
@@ -1477,6 +1477,8 @@ char *generateAircraftJson(const char *url_path, int *len) {
         if (a->messages < 2) { // basic filter for bad decodes
             continue;
         }
+        if ((now - a->seen) > 90E3) // don't include stale aircraft in the JSON
+            continue;
 
         if (first)
             first = 0;

--- a/readsb.c
+++ b/readsb.c
@@ -170,6 +170,7 @@ static void modesInitConfig(void) {
     Modes.mode_ac_auto = 1;
     Modes.nfix_crc = 1;
     Modes.biastee = 0;
+    Modes.filter_persistence = 2;
 
     sdrInitConfig();
 }
@@ -539,6 +540,9 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
             break;
         case OptAggressive:
             Modes.nfix_crc = MODES_MAX_BITERRORS;
+            break;
+        case OptFilterPersistence:
+            Modes.filter_persistence = atoi(arg);
             break;
         case OptInteractive:
             Modes.interactive = 1;

--- a/readsb.h
+++ b/readsb.h
@@ -353,6 +353,7 @@ struct
   int net_output_flush_size; // Minimum Size of output data
   int net_push_server_mode; // Data mode to feed push server
   int net_push_delay;
+  int filter_persistence; // Maximum number of consecutive implausible positions from global CPR to invalidate a known position.
   uint64_t net_heartbeat_interval; // TCP heartbeat interval (milliseconds)
   uint64_t net_output_flush_interval; // Maximum interval (in milliseconds) between outputwrites
   double fUserLat; // Users receiver/antenna lat/lon needed for initial surface location
@@ -642,6 +643,7 @@ enum {
   OptFix,
   OptNoFix,
   OptNoCrcCheck,
+  OptFilterPersistence,
   OptAggressive,
   OptMlat,
   OptStats,

--- a/track.c
+++ b/track.c
@@ -128,7 +128,7 @@ static struct aircraft *trackCreateAircraft(struct modesMessage *mm) {
     F(nav_modes, 60, 70); // ADS-B or Comm-B
     F(cpr_odd, 60, 70); // ADS-B only
     F(cpr_even, 60, 70); // ADS-B only
-    F(position, 60, 70); // ADS-B only
+    F(position, 60, 10*60); // ADS-B only
     F(nic_a, 60, 70); // ADS-B only
     F(nic_c, 60, 70); // ADS-B only
     F(nic_baro, 60, 70); // ADS-B only
@@ -418,7 +418,16 @@ static int doLocalCPR(struct aircraft *a, struct modesMessage *mm, double *lat, 
         if (a->pos_rc < *rc)
             *rc = a->pos_rc;
 
-        range_limit = 50e3;
+        range_limit = 1852*100; // 100NM
+        // 100 NM in the 10 minutes of position validity means 600 knots which
+        // is fast but happens even for commercial airliners.
+        // It's not a problem if this limitation fails every now and then.
+        // A wrong relative position decode would require the aircraft to
+        // travel 360-100=260 NM in the 10 minutes of position validity.
+        // This is impossible for planes slower than 1560 knots/Mach 2.3 over the ground.
+        // Thus this range limit combined with the 10 minutes of position
+        // validity should not provide bad positions (1 cell away).
+
         relative_to = 1;
     } else if (!surface && (Modes.bUserFlags & MODES_USER_LATLON_VALID)) {
         reflat = Modes.fUserLat;

--- a/track.c
+++ b/track.c
@@ -395,6 +395,7 @@ static int doLocalCPR(struct aircraft *a, struct modesMessage *mm, double *lat, 
     int result;
     int fflag = mm->cpr_odd;
     int surface = (mm->cpr_type == CPR_SURFACE);
+    int relative_to = 0; // aircraft(1) or receiver(2) relative
 
     if (fflag) {
         *nic = a->cpr_odd_nic;
@@ -414,6 +415,7 @@ static int doLocalCPR(struct aircraft *a, struct modesMessage *mm, double *lat, 
             *rc = a->pos_rc;
 
         range_limit = 50e3;
+        relative_to = 1;
     } else if (!surface && (Modes.bUserFlags & MODES_USER_LATLON_VALID)) {
         reflat = Modes.fUserLat;
         reflon = Modes.fUserLon;
@@ -436,6 +438,7 @@ static int doLocalCPR(struct aircraft *a, struct modesMessage *mm, double *lat, 
         } else {
             return (-1); // Can't do receiver-centered checks at all
         }
+        relative_to = 2;
     } else {
         // No local reference, give up
         return (-1);
@@ -468,7 +471,7 @@ static int doLocalCPR(struct aircraft *a, struct modesMessage *mm, double *lat, 
         return -1;
     }
 
-    return 0;
+    return relative_to;
 }
 
 static uint64_t time_between(uint64_t t1, uint64_t t2) {
@@ -546,16 +549,23 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm) {
     if (location_result == -1) {
         location_result = doLocalCPR(a, mm, &new_lat, &new_lon, &new_nic, &new_rc);
 
-        if (location_result > 0 && accept_data(&a->position_valid, mm->source)) {
+        if (location_result >= 0 && accept_data(&a->position_valid, mm->source)) {
             Modes.stats_current.cpr_local_ok++;
             mm->cpr_relative = 1;
+
+            if (location_result == 1) {
+                Modes.stats_current.cpr_local_aircraft_relative++;
+            }
+            if (location_result == 2) {
+                Modes.stats_current.cpr_local_receiver_relative++;
+            }
         } else {
             Modes.stats_current.cpr_local_skipped++;
             location_result = -1;
         }
     }
 
-    if (location_result == 0) {
+    if (location_result >= 0) {
         // If we sucessfully decoded, back copy the results to mm so that we can print them in list output
         mm->cpr_decoded = 1;
         mm->decoded_lat = new_lat;

--- a/track.c
+++ b/track.c
@@ -564,9 +564,9 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm) {
                 Modes.stats_current.cpr_global_ok++;
 
                 if (mm->cpr_odd)
-                    a->pos_reliable_odd = min(a->pos_reliable_odd + 1, POS_RELIABLE_MAX);
+                    a->pos_reliable_odd = min(a->pos_reliable_odd + 1, Modes.filter_persistence);
                 else
-                    a->pos_reliable_even = min(a->pos_reliable_even + 1, POS_RELIABLE_MAX);
+                    a->pos_reliable_even = min(a->pos_reliable_even + 1, Modes.filter_persistence);
 
                 if (trackDataValid(&a->gs_valid))
                     a->gs_last_pos = a->gs;

--- a/track.c
+++ b/track.c
@@ -519,11 +519,22 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm) {
             fprintf(stderr, "global CPR failure (invalid) for (%06X).\n", a->addr);
 #endif
             // Global CPR failed because the position produced implausible results.
-            // This is bad data. Discard both odd and even messages and wait for a fresh pair.
-            // Also disable aircraft-relative positions until we have a new good position (but don't discard the
-            // recorded position itself)
+            // This is bad data.
+            // At least one of the CPRs is bad, mark them both invalid.
+            // If we are not confident in the position, invalidate it as well.
+
             Modes.stats_current.cpr_global_bad++;
-            a->cpr_odd_valid.source = a->cpr_even_valid.source = a->position_valid.source = SOURCE_INVALID;
+
+            a->cpr_odd_valid.source = SOURCE_INVALID;
+            a->cpr_even_valid.source = SOURCE_INVALID;
+            a->pos_reliable_odd--;
+            a->pos_reliable_even--;
+
+            if (a->pos_reliable_odd <= 0 || a->pos_reliable_even <=0) {
+                a->position_valid.source = SOURCE_INVALID;
+                a->pos_reliable_odd = 0;
+                a->pos_reliable_even = 0;
+            }
 
             return;
         } else if (location_result == -1) {
@@ -538,6 +549,12 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm) {
         } else {
             if (accept_data(&a->position_valid, mm->source)) {
                 Modes.stats_current.cpr_global_ok++;
+
+                if (mm->cpr_odd)
+                    a->pos_reliable_odd = min(a->pos_reliable_odd + 1, POS_RELIABLE_MAX);
+                else
+                    a->pos_reliable_even = min(a->pos_reliable_even + 1, POS_RELIABLE_MAX);
+
             } else {
                 Modes.stats_current.cpr_global_skipped++;
                 location_result = -2;
@@ -1248,6 +1265,13 @@ static void trackRemoveStaleAircraft(uint64_t now) {
             EXPIRE(gva);
             EXPIRE(sda);
 #undef EXPIRE
+
+            // reset position reliability when the position has expired
+            if (a->position_valid.source == SOURCE_INVALID) {
+                a->pos_reliable_odd = 0;
+                a->pos_reliable_even = 0;
+            }
+
             prev = a;
             a = a->next;
         }

--- a/track.c
+++ b/track.c
@@ -806,6 +806,7 @@ static int altitude_to_feet(int raw, altitude_unit_t unit) {
 
 struct aircraft *trackUpdateFromMessage(struct modesMessage *mm) {
     struct aircraft *a;
+    unsigned int cpr_new = 0;
 
     if (mm->msgtype == 32) {
         // Mode A/C, just count it (we ignore SPI)
@@ -1022,6 +1023,7 @@ struct aircraft *trackUpdateFromMessage(struct modesMessage *mm) {
         a->cpr_even_lat = mm->cpr_lat;
         a->cpr_even_lon = mm->cpr_lon;
         compute_nic_rc_from_message(mm, a, &a->cpr_even_nic, &a->cpr_even_rc);
+        cpr_new = 1;
     }
 
     // CPR, odd
@@ -1030,6 +1032,7 @@ struct aircraft *trackUpdateFromMessage(struct modesMessage *mm) {
         a->cpr_odd_lat = mm->cpr_lat;
         a->cpr_odd_lon = mm->cpr_lon;
         compute_nic_rc_from_message(mm, a, &a->cpr_odd_nic, &a->cpr_odd_rc);
+        cpr_new = 1;
     }
 
     if (mm->accuracy.sda_valid && accept_data(&a->sda_valid, mm->source)) {
@@ -1081,8 +1084,8 @@ struct aircraft *trackUpdateFromMessage(struct modesMessage *mm) {
         combine_validity(&a->altitude_geom_valid, &a->altitude_baro_valid, &a->geom_delta_valid);
     }
 
-    // If we've got a new cprlat or cprlon
-    if (mm->cpr_valid) {
+    // If we've got a new cpr_odd or cpr_even
+    if (cpr_new) {
         updatePosition(a, mm);
     }
 

--- a/track.h
+++ b/track.h
@@ -55,13 +55,10 @@
 #define DUMP1090_TRACK_H
 
 /* Maximum age of tracked aircraft in milliseconds */
-#define TRACK_AIRCRAFT_TTL 300000
+#define TRACK_AIRCRAFT_TTL (10*60000)
 
 /* Maximum age of a tracked aircraft with only 1 message received, in milliseconds */
 #define TRACK_AIRCRAFT_ONEHIT_TTL 60000
-
-/* Maximum validity of an aircraft position */
-#define TRACK_AIRCRAFT_POSITION_TTL 60000
 
 /* Minimum number of repeated Mode A/C replies with a particular Mode A code needed in a
  * 1 second period before accepting that code.

--- a/track.h
+++ b/track.h
@@ -183,6 +183,7 @@ struct aircraft
   unsigned pos_rc; // Rc of last computed position
   int pos_reliable_odd; // Number of good global CPRs, indicates position reliability
   int pos_reliable_even;
+  float gs_last_pos; // Save a groundspeed associated with the last position
 
   // data extracted from opstatus etc
   int adsb_version; // ADS-B version (from ADS-B operational status); -1 means no ADS-B messages seen

--- a/track.h
+++ b/track.h
@@ -65,9 +65,6 @@
  */
 #define TRACK_MODEAC_MIN_MESSAGES 4
 
-/* Maximum number of global CPR failures it takes to invalidate the known position */
-#define POS_RELIABLE_MAX 2
-
 /* Special value for Rc unknown */
 #define RC_UNKNOWN 0
 

--- a/track.h
+++ b/track.h
@@ -68,6 +68,9 @@
  */
 #define TRACK_MODEAC_MIN_MESSAGES 4
 
+/* Maximum number of global CPR failures it takes to invalidate the known position */
+#define POS_RELIABLE_MAX 2
+
 /* Special value for Rc unknown */
 #define RC_UNKNOWN 0
 
@@ -178,6 +181,8 @@ struct aircraft
   double lat, lon; // Coordinated obtained from CPR encoded data
   unsigned pos_nic; // NIC of last computed position
   unsigned pos_rc; // Rc of last computed position
+  int pos_reliable_odd; // Number of good global CPRs, indicates position reliability
+  int pos_reliable_even;
 
   // data extracted from opstatus etc
   int adsb_version; // ADS-B version (from ADS-B operational status); -1 means no ADS-B messages seen
@@ -292,6 +297,15 @@ static inline unsigned
 indexToModeA (unsigned index)
 {
   return (index & 0007) | ((index & 0070) << 1) | ((index & 0700) << 2) | ((index & 07000) << 3);
+}
+
+static inline int
+min (int a, int b)
+{
+  if (a < b)
+    return a;
+  else
+    return b;
 }
 
 #endif


### PR DESCRIPTION
First 2 patches: Bugfixes
Other patches: Improving filtering and relative CPR

After having tested these changes for a couple of days against a reference version getting the same beast input, all seems solid.
I turned on the speed filter debugging for both versions, and the old version definitely produced some false positives especially for landing aircraft as the new ground speed is used as reference while the majority of the landing run was at higher speed.
I haven't seen any instances of the new filter permitting actual bogus positions where the old version filter didn't.

The pos_reliable change works very well as it allows getting some positions further away as the aircraft is leaving the coverage of the receiver. If a stray position message then reaches the receiver, local CPR decoding can be done where it couldn't be before giving you a position.
It's not a huge number of position decodes but they are in areas where you get few position reports, so it matters in my opinion.
In the last patch i've added a console option in regards to pos_reliable, so you can revert to the old behaviour. But it should be an all around improvement using at least 2 as a value for filterPersistence.

I'm not sure which value you would prefer in regards to stale aircraft in the JSON file.
90 seconds seems plenty, but that's up to you
As aircraft are now retained twice as long, to keep the current behaviour 300 seconds instead of 90 would be the way to go.