### PR TITLE
Support Stratux

### DIFF
--- a/help.h
+++ b/help.h
@@ -82,6 +82,7 @@ static struct argp_option options[] =
     {"net-ro-port", OptNetRoPorts, "<ports>", 0, "TCP raw output listen ports (default: 30002)", 2},
     {"net-sbs-port", OptNetSbsPorts, "<ports>", 0, "TCP BaseStation output listen ports (default: 30003)", 2},
     {"net-sbs-in-port", OptNetSbsInPorts, "<ports>", 0, "TCP BaseStation input listen ports (default: 0)", 2},
+    {"net-stratux-port", OptNetStratuxPorts, "<ports>", 0, "TCP Stratux output listen ports (default: not enabled)", 2},
     {"net-bi-port", OptNetBiPorts, "<ports>", 0, "TCP Beast input listen ports  (default: 30004,30104)", 2},
     {"net-vrs-port", OptNetVRSPorts, "<ports>", 0, "TCP VRS json output listen ports (default: 0)", 2},
     {"net-beast-reduce-out-port", OptNetBeastReducePorts, "<ports>", 0, "TCP BeastReduce output listen ports (default: 0)", 2},

--- a/net_io.c
+++ b/net_io.c
@@ -86,6 +86,7 @@ static int decodeSbsLine(struct client *c, char *line, int remote);
 static void send_raw_heartbeat(struct net_service *service);
 static void send_beast_heartbeat(struct net_service *service);
 static void send_sbs_heartbeat(struct net_service *service);
+static void send_stratux_heartbeat(struct net_service *service);
 
 static void writeFATSVEvent(struct modesMessage *mm, struct aircraft *a);
 static void writeFATSVPositionUpdate(float lat, float lon, float alt);
@@ -474,6 +475,11 @@ void modesInitNet(void) {
 
     sbs_in = serviceInit("Basestation TCP input", NULL, NULL, READ_MODE_ASCII, "\n",  decodeSbsLine);
     serviceListen(sbs_in, Modes.net_bind_address, Modes.net_input_sbs_ports);
+
+    if (Modes.net_output_stratux_ports) {
+        s = serviceInit("Stratux TCP output", &Modes.stratux_out, send_stratux_heartbeat, READ_MODE_IGNORE, NULL, NULL);
+        serviceListen(s, Modes.net_bind_address, Modes.net_output_stratux_ports);
+    }
 
     raw_in = serviceInit("Raw TCP input", NULL, NULL, READ_MODE_ASCII, "\n", decodeHexMessage);
     serviceListen(raw_in, Modes.net_bind_address, Modes.net_input_raw_ports);
@@ -887,6 +893,253 @@ static void send_raw_heartbeat(struct net_service *service) {
 //
 //=========================================================================
 //
+// Write Stratux output to TCP clients
+//
+static void modesSendStratuxOutput(struct modesMessage *mm, struct aircraft *a) {
+    char *p;
+    struct timespec now;
+    struct tm    stTime_receive, stTime_now;
+    int          msgType;
+
+    // TODO: mm->reliable is available in the latest dump1090-fa, but not in
+    // readsb
+    /*
+    // Don't ever send unreliable messages via SBS output
+    if (!mm->reliable && !a->reliable)
+        return;
+    */
+
+    //// For now, suppress non-ICAO addresses
+    //if (mm->addr & MODES_NON_ICAO_ADDRESS)
+    //    return;
+
+    p = prepareWrite(&Modes.stratux_out, 1000); // larger buffer size needed vs SBS
+    if (!p)
+        return;
+
+    // NOTE: not sure about message types, so keep the original code from
+    // stratux/dump1090 as-is.
+    //
+    // Decide on the basic SBS Message Type
+    if        ((mm->msgtype ==  4) || (mm->msgtype == 20)) {
+        msgType = 5;
+    } else if ((mm->msgtype ==  5) || (mm->msgtype == 21)) {
+        msgType = 6;
+    } else if ((mm->msgtype ==  0) || (mm->msgtype == 16)) {
+        msgType = 7;
+    } else if  (mm->msgtype == 11) {
+        msgType = 8;
+    } else if ((mm->msgtype != 17) && (mm->msgtype != 18)) {
+        return;
+    } else if ((mm->metype >= 1) && (mm->metype <=  4)) {
+        msgType = 1;
+    } else if ((mm->metype >= 5) && (mm->metype <=  8)) {
+        if (mm->cpr_decoded)
+            {msgType = 2;}
+        else
+            {msgType = 7;}
+    } else if ((mm->metype >= 9) && (mm->metype <= 18)) {
+        if (mm->cpr_decoded)
+            {msgType = 3;}
+        else
+            {msgType = 7;}
+    } else if ((mm->metype == 29) || (mm->metype == 31)) {
+        msgType = 9; // new message type for target state and operational status messages
+    } else if (mm->metype !=  19) {
+        return;
+    } else if ((mm->mesub == 1) || (mm->mesub == 2)) {
+        msgType = 4;
+    } else {
+        return;
+    }
+
+    // Begin populating the traffic.go fields.
+    // ICAO address, Mode S message types, and signal level
+
+    int cacf = 0; // overload the JSON "CA" field to report CA (DF11 or DF17), CF (DF18), or zero (all other DF types)
+    if ((mm->msgtype == 11) || (mm->msgtype == 17)) {
+        cacf = mm->CA;
+    } else if (mm->msgtype == 18) {
+        cacf = mm->CF;
+    }
+
+    p += sprintf(p,
+            "{\"Icao_addr\":%d,"
+            "\"DF\":%d,\"CA\":%d,"
+            "\"TypeCode\":%d,"
+            "\"SubtypeCode\":%d,"
+            "\"SBS_MsgType\":%d,"
+            "\"SignalLevel\":%f,",
+            mm->addr,
+            mm->msgtype, cacf,
+            mm->metype,
+            mm->mesub,
+            msgType,
+            mm->signalLevel); // what precision and range is needed for RSSI?
+
+    // Find current system time
+    clock_gettime(CLOCK_REALTIME, &now);
+    gmtime_r(&now.tv_sec, &stTime_now);  // we expect UTC
+
+    // Find message reception time
+    time_t received = (time_t) (mm->sysTimestampMsg / 1000);
+    localtime_r(&received, &stTime_receive);
+
+    //// callsign
+    if (mm->callsign_valid)
+        p += sprintf(p, "\"Tail\":\"%s\",", mm->callsign);
+    else
+        p += sprintf(p, "\"Tail\":null,");
+
+    //// altitude & gnss
+    bool alt_is_geom = false;
+    if (Modes.use_gnss && mm->altitude_geom_valid) {
+        p += sprintf(p, "\"Alt\":%d,",mm->altitude_geom);
+        alt_is_geom = true;
+    } else if (mm->altitude_baro_valid)
+        p += sprintf(p, "\"Alt\":%d,",mm->altitude_baro);
+    else
+        p += sprintf(p, "\"Alt\":null,");
+
+    // altitude source
+    if (alt_is_geom)
+        p += sprintf(p, "\"AltIsGNSS\":true,");
+    else
+        p += sprintf(p, "\"AltIsGNSS\":false,");
+
+    // GNSS alt. delta From baro alt.
+    if (trackDataValid(&a->geom_delta_valid))
+        p += sprintf(p, "\"GnssDiffFromBaroAlt\":%d,",a->geom_delta);
+    else
+        p += sprintf(p, "\"GnssDiffFromBaroAlt\":null,");
+    ////
+
+    //// ground speed and track
+    if (mm->gs_valid)
+        p += sprintf(p, "\"Speed_valid\":true,\"Speed\":%.0f,", mm->gs.selected);
+    else
+        p += sprintf(p, "\"Speed_valid\":false,\"Speed\":null,");
+
+    //// ground heading
+    if (mm->heading_valid && mm->heading_type == HEADING_GROUND_TRACK)
+        p += sprintf(p, "\"Track\":%.0f,", mm->heading);
+    else
+        p += sprintf(p, "\"Track\":null,");
+
+    //// position
+    if (mm->cpr_decoded)
+        p += sprintf(p, "\"Lat\":%.6f,\"Lng\":%.6f,\"Position_valid\":true,",
+                    mm->decoded_lat, mm->decoded_lon);
+    else
+        p += sprintf(p, "\"Lat\":null,\"Lng\":null,\"Position_valid\":false,");
+
+    //// vrate
+    if (Modes.use_gnss) {
+        if (mm->geom_rate_valid)
+            p += sprintf(p, "\"Vvel\":%d,", mm->geom_rate);
+        else if (mm->baro_rate_valid)
+            p += sprintf(p, "\"Vvel\":%d,", mm->baro_rate);
+        else
+            p += sprintf(p,  "\"Vvel\":null,");
+    } else {
+        if (mm->baro_rate_valid)
+            p += sprintf(p, "\"Vvel\":%d,", mm->baro_rate);
+        else if (mm->geom_rate_valid)
+            p += sprintf(p, "\"Vvel\":%d,", mm->geom_rate);
+        else
+            p += sprintf(p,  "\"Vvel\":null,");
+    }
+
+    //// squawk
+    if (mm->squawk_valid)
+        p += sprintf(p, "\"Squawk\":%x,", mm->squawk);
+    else
+        p += sprintf(p, "\"Squawk\":null,");
+
+    // TODO: squawk changing alert support in stratux?
+    // TODO: squawk emergency flag?
+    // TODO: squawk ident flag?
+
+    // airground
+    switch (mm->airground) {
+        case AG_GROUND:
+            p += sprintf(p, "\"OnGround\":true,");
+            break;
+        case AG_AIRBORNE:
+            p += sprintf(p, "\"OnGround\":false,");
+            break;
+        default:
+            p += sprintf(p, "\"OnGround\":null,");
+    }
+
+    // navigation accuracy category - position
+    if (mm->accuracy.nac_p_valid) {
+        p += sprintf(p, "\"NACp\":%d,", mm->accuracy.nac_p);
+    } else {
+        p += sprintf(p, "\"NACp\":null,");
+    }
+
+    // emitter type
+    int emitter = 0;
+    int setEmitter = 0;
+    if ((mm->msgtype ==  17) || (mm->msgtype == 18)) {
+        switch (mm->metype) {
+            case 1:
+                emitter = ((mm->mesub) | 0x18);
+                setEmitter = 1;
+                break;
+            case 2:
+                emitter = ((mm->mesub) | 0x10);
+                setEmitter = 1;
+                break;
+            case 3:
+                emitter = ((mm->mesub) | 0x08);
+                setEmitter = 1;
+                break;
+            case 4:
+                emitter = (mm->mesub);
+                setEmitter = 1;
+                break;
+        }
+    }
+
+    if (setEmitter)
+        p += sprintf(p, "\"Emitter_category\":%d,", emitter);
+    else
+        p += sprintf(p, "\"Emitter_category\":null,");
+
+    // Time message received (based on system clock). Format is 2016-02-20T06:35:43.155Z
+    p += sprintf(p, "\"Timestamp\":\"%04d-%02d-%02dT%02d:%02d:%02d.%03dZ\"",
+            (stTime_receive.tm_year+1900),(stTime_receive.tm_mon+1),
+            stTime_receive.tm_mday, stTime_receive.tm_hour,
+            stTime_receive.tm_min, stTime_receive.tm_sec,
+            (unsigned)(mm->sysTimestampMsg % 1000));
+
+    p += sprintf(p, "}\r\n");
+
+    completeWrite(&Modes.stratux_out, p);
+}
+
+static void send_stratux_heartbeat(struct net_service *service)
+{
+    static char *heartbeat_message = "{\"Icao_addr\":134217727}\r\n";  // 0x07FFFFFF. Overflows 24-bit ICAO to signal invalic #, need to validate that this won't cause problems with traffic.go
+    char *data;
+    int len = strlen(heartbeat_message);
+
+    if (!service->writer)
+        return;
+
+    data = prepareWrite(service->writer, len);
+    if (!data)
+        return;
+
+    memcpy(data, heartbeat_message, len);
+    completeWrite(service->writer, data + len);
+}
+
+//
+//=========================================================================
+//
 // Read SBS input from TCP clients
 //
 static int decodeSbsLine(struct client *c, char *line, int remote) {
@@ -1205,6 +1458,8 @@ void modesQueueOutput(struct modesMessage *mm, struct aircraft *a) {
         // Don't ever forward 2-bit-corrected messages via SBS output.
         // Don't ever forward mlat messages via SBS output.
         modesSendSBSOutput(mm, a);
+        if (Modes.net_output_stratux_ports)
+            modesSendStratuxOutput(mm, a);
     }
 
     if (!is_mlat && (Modes.net_verbatim || mm->correctedbits < 2)) {

--- a/readsb.c
+++ b/readsb.c
@@ -160,6 +160,7 @@ static void modesInitConfig(void) {
     Modes.net_input_sbs_ports = strdup("0");
     Modes.net_input_beast_ports = strdup("30004,30104");
     Modes.net_output_beast_ports = strdup("30005");
+    Modes.net_output_stratux_ports = NULL;
     Modes.net_output_beast_reduce_ports = strdup("0");
     Modes.net_output_beast_reduce_interval = 125;
     Modes.net_output_vrs_ports = strdup("0");
@@ -658,6 +659,11 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
         case OptNetSbsInPorts:
             free(Modes.net_input_sbs_ports);
             Modes.net_input_sbs_ports = strdup(arg);
+            break;
+        case OptNetStratuxPorts:
+            if (Modes.net_output_stratux_ports)
+                free(Modes.net_output_stratux_ports);
+            Modes.net_output_stratux_ports = strdup(arg);
             break;
         case OptNetVRSPorts:
             free(Modes.net_output_vrs_ports);

--- a/readsb.h
+++ b/readsb.h
@@ -341,6 +341,7 @@ struct
   struct net_writer beast_out; // Beast-format output
   struct net_writer beast_reduce_out; // Reduced data Beast-format output
   struct net_writer sbs_out; // SBS-format output
+  struct net_writer stratux_out; // Stratux-format output
   struct net_writer vrs_out; // SBS-format output
   struct net_writer fatsv_out; // FATSV-format output
 
@@ -373,6 +374,7 @@ struct
   char *net_input_raw_ports; // List of raw input TCP ports
   char *net_output_sbs_ports; // List of SBS output TCP ports
   char *net_input_sbs_ports; // List of SBS input TCP ports
+  char *net_output_stratux_ports; // List of Stratux output TCP ports
   char *net_input_beast_ports; // List of Beast input TCP ports
   char *net_output_beast_ports; // List of Beast output TCP ports
   char *net_output_beast_reduce_ports; // List of Beast output TCP ports
@@ -676,6 +678,7 @@ enum {
   OptNetRoPorts,
   OptNetSbsPorts,
   OptNetSbsInPorts,
+  OptNetStratuxPorts,
   OptNetBiPorts,
   OptNetBoPorts,
   OptNetBeastReducePorts,


### PR DESCRIPTION
This adds the Stratux TCP output support. It is disabled by default and can be enabled by `--net-stratux-port=30006`.