### PR TITLE
network: avoid segfault in freeaddrinfo

### DIFF
--- a/anet.c
+++ b/anet.c
@@ -212,7 +212,10 @@ static int anetTcpGenericConnect(char *err, char *addr, char *service, int flags
             if (ss) {
                 memcpy(ss, p->ai_addr, sizeof(*ss));
             }
-            freeaddrinfo(gai_result);
+            if (gai_result) {
+                freeaddrinfo(gai_result);
+                gai_result = NULL;
+            }
             return s;
         }
 
@@ -220,7 +223,10 @@ static int anetTcpGenericConnect(char *err, char *addr, char *service, int flags
         anetCloseSocket(s);
     }
 
-    freeaddrinfo(gai_result);
+    if (gai_result) {
+        freeaddrinfo(gai_result);
+        gai_result = NULL;
+    }
     return ANET_ERR;
 }
 
@@ -368,7 +374,10 @@ int anetTcpServer(char *err, char *service, char *bindaddr, int *fds, int nfds)
         fds[i++] = s;
     }
 
-    freeaddrinfo(gai_result);
+    if (gai_result) {
+        freeaddrinfo(gai_result);
+        gai_result = NULL;
+    }
     return (i > 0 ? i : ANET_ERR);
 }
 

--- a/net_io.c
+++ b/net_io.c
@@ -3285,7 +3285,10 @@ void cleanupNetwork(void) {
     for (int i = 0; i < Modes.net_connectors_count; i++) {
         struct net_connector *con = Modes.net_connectors[i];
         free(con->address);
-        freeaddrinfo(con->addr_info);
+        if (con->addr_info) {
+            freeaddrinfo(con->addr_info);
+            con->addr_info = NULL;
+        }
         if (con->mutex) {
             pthread_mutex_unlock(con->mutex);
             pthread_mutex_destroy(con->mutex);

--- a/viewadsb.c
+++ b/viewadsb.c
@@ -308,7 +308,10 @@ int main(int argc, char **argv) {
     }
     // Free local service and client
     if (s) free(s);
-    freeaddrinfo(con->addr_info);
+    if (con->addr_info) {
+        freeaddrinfo(con->addr_info);
+        con->addr_info = NULL;
+    }
     pthread_mutex_unlock(con->mutex);
     pthread_mutex_destroy(con->mutex);
     free(con->mutex);


### PR DESCRIPTION
Calling freeaddrinfo(NULL) when using musl libc causes a segfault.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>