### PR TITLE
fix sleep sometimes lasting longer than intended

### DIFF
--- a/readsb.c
+++ b/readsb.c
@@ -819,23 +819,18 @@ int main(int argc, char **argv) {
      * This rules also in case a local Mode-S Beast is connected via USB.
      */
     if (Modes.sdr_type == SDR_NONE || Modes.sdr_type == SDR_MODESBEAST || Modes.sdr_type == SDR_GNS) {
-        int64_t background_cpu_millis = 0;
-        int64_t prev_cpu_millis = 0;
         struct timespec slp = {0, 20 * 1000 * 1000};
         while (!Modes.exit) {
             int64_t sleep_millis = 100;
             struct timespec start_time;
 
-            prev_cpu_millis = background_cpu_millis;
-
             start_cpu_timing(&start_time);
             backgroundTasks();
-            end_cpu_timing(&start_time, &Modes.stats_current.background_cpu);
+            int64_t elapsed = end_cpu_timing(&start_time, &Modes.stats_current.background_cpu);
 
-            background_cpu_millis = (int64_t) Modes.stats_current.background_cpu.tv_sec * 1000UL +
-                Modes.stats_current.background_cpu.tv_nsec / 1000000UL;
-            sleep_millis = sleep_millis - (background_cpu_millis - prev_cpu_millis);
-            sleep_millis = (sleep_millis <= 20) ? 20 : sleep_millis;
+            sleep_millis = 100 - elapsed;
+            sleep_millis = (sleep_millis < 10) ? 10 : sleep_millis;
+            sleep_millis = (sleep_millis > 100) ? 100 : sleep_millis;
 
             //fprintf(stderr, "%ld\n", sleep_millis);
 

--- a/util.c
+++ b/util.c
@@ -92,11 +92,13 @@ void start_cpu_timing(struct timespec *start_time) {
     clock_gettime(CLOCK_THREAD_CPUTIME_ID, start_time);
 }
 
-/* add difference between start_time and the current CPU time to add_to */
-void end_cpu_timing(const struct timespec *start_time, struct timespec *add_to) {
+/* add difference between start_time and the current CPU time to add_to, return elapsed time */
+int64_t end_cpu_timing(const struct timespec *start_time, struct timespec *add_to) {
     struct timespec end_time;
     clock_gettime(CLOCK_THREAD_CPUTIME_ID, &end_time);
     add_to->tv_sec += end_time.tv_sec - start_time->tv_sec;
     add_to->tv_nsec += end_time.tv_nsec - start_time->tv_nsec;
     normalize_timespec(add_to);
+    return ((int64_t) end_time.tv_sec * 1000UL + end_time.tv_nsec / 1000000UL)
+        - ((int64_t) start_time->tv_sec * 1000UL + start_time->tv_nsec / 1000000UL);
 }

--- a/util.h
+++ b/util.h
@@ -55,7 +55,7 @@ void normalize_timespec (struct timespec *ts);
 /* record current CPU time in start_time */
 void start_cpu_timing (struct timespec *start_time);
 
-/* add difference between start_time and the current CPU time to add_to */
-void end_cpu_timing (const struct timespec *start_time, struct timespec *add_to);
+/* add difference between start_time and the current CPU time to add_to, return elapsed time */
+int64_t end_cpu_timing (const struct timespec *start_time, struct timespec *add_to);
 
 #endif


### PR DESCRIPTION
stats being reset messes with the calculation, use the timing
measurement directly instead of using the current stats value and
subtracting
end_cpu_timing: return elapsed time which is quite useful for debugging
as well